### PR TITLE
wsgiproxy2 0.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,35 @@
-{% set version = "0.4.6" %}
+{% set name = "WSGIProxy2" %}
+{% set version = "0.5.1" %}
 
 package:
-  name: wsgiproxy2
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/W/WSGIProxy2/WSGIProxy2-{{ version }}.tar.gz
-  sha256: cee2a64abc193cc96c7ff1208b709335e9a4d1316ce84b91501102166d814c9a
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 0d9ecb141de720e2fd4f7a275a4a83a961ffeb6717483d940021ffa1c46f665c
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation  -vv
 
 requirements:
   host:
-    - python
     - pip
+    - python
+    - setuptools >=61.0.0
   run:
     - python
-    - setuptools
     - webob
-    - six
 
 test:
   imports:
     - wsgiproxy
+  requires:
+    - pip
+  commands:
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name|lower }}')=='{{ version }}')"
 
 about:
   home: https://github.com/gawel/WSGIProxy2
@@ -33,7 +37,8 @@ about:
   license_family: MIT
   license_file: COPYING
   summary: A WSGI Proxy with various http client backends
-  doc_url: https://wsgiproxy2.readthedocs.org
+  description: A WSGI Proxy with various http client backends
+  doc_url: https://github.com/gawel/WSGIProxy2/tree/master/docs
   dev_url: https://github.com/gawel/WSGIProxy2
 
 extra:


### PR DESCRIPTION
wsgiproxy2 0.5.1

**Destination channel:** Default

### Links

- [PKG-9180](https://anaconda.atlassian.net/browse/PKG-9180)
- dev_url:        https://github.com/gawel/WSGIProxy2/tree/0.5.1
- conda_forge:    https://github.com/conda-forge/wsgiproxy2-feedstock
- pypi:           https://pypi.org/project/WSGIProxy2/0.5.1/
- pypi inspector: https://inspector.pypi.io/project/wsgiproxy2/0.5.1/

### Explanation of changes:

- new version


[PKG-9180]: https://anaconda.atlassian.net/browse/PKG-9180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ